### PR TITLE
Fixing messenging refresh #191   Fixed auto-scroll to most recent message #195

### DIFF
--- a/views/doctor_messaging.ejs
+++ b/views/doctor_messaging.ejs
@@ -24,6 +24,68 @@
 
 
 </head>
+<!--
+<script>
+  function autoRefresh()
+  {
+    document.getElementById("msg-inbox").innerHTML = `
+                  <div class="chats">
+                    <div class="msg-page">
+
+                        <%if(messageList.length!=0){%>
+                          <%var i=1;%>
+                          <% messageList.forEach(function(data){%>
+
+
+                        <% if (data.sender_uuid == doctor_uuid){ %>
+
+                        <div class="outgoing-chats">
+
+                          <div class="outgoing-chats-msg">
+                              <p><%=data.message%></p>
+                              <span class="time"><%=data.date_time%> </span>
+
+                          </div>
+                          <div class="outgoing-chats-img">
+                            <img src="/img/doctor_user.png">
+                          </div>
+                        </div>
+
+                        <% } else {%>
+                        <div class="received-chats">
+                          <div class="received-chats-img">
+                            <img src="/img/user2.png">
+                          </div>
+                          <div class="received-msg">
+                            <div class="received-msg-inbox">
+                              <p><%=data.message%></p>
+                              <span class="time"><%=data.date_time%> </span>
+                            </div>
+                          </div>
+                        </div>
+
+                        <% } i++; }) %>
+                        <% } else{ %>
+                                      <tr>
+                                          <td colspan="7">No Previous Conversation Found</td>
+                                      </tr>
+                        <% } %>
+
+
+                    </div>
+                  </div>
+                `;
+  }
+   setInterval('autoRefresh()', 5000);
+</script>
+-->
+<script type="text/javascript">
+  window.onload = function scroll_bottom()
+  {
+  var elem = document.getElementById('msg-inbox');
+  elem.scrollTop = elem.scrollHeight;
+  }
+</script>
 
 <body>
   <!--Sidebar for Navigation-->
@@ -52,7 +114,7 @@
               </div>
 
               <div class="chat-page">
-                <div class="msg-inbox">
+                <div class="msg-inbox" id="msg-inbox">
                   <div class="chats">
                     <div class="msg-page">
 

--- a/views/doctor_messaging.ejs
+++ b/views/doctor_messaging.ejs
@@ -24,61 +24,8 @@
 
 
 </head>
-<!--
-<script>
-  function autoRefresh()
-  {
-    document.getElementById("msg-inbox").innerHTML = `
-                  <div class="chats">
-                    <div class="msg-page">
 
-                        <%if(messageList.length!=0){%>
-                          <%var i=1;%>
-                          <% messageList.forEach(function(data){%>
-
-
-                        <% if (data.sender_uuid == doctor_uuid){ %>
-
-                        <div class="outgoing-chats">
-
-                          <div class="outgoing-chats-msg">
-                              <p><%=data.message%></p>
-                              <span class="time"><%=data.date_time%> </span>
-
-                          </div>
-                          <div class="outgoing-chats-img">
-                            <img src="/img/doctor_user.png">
-                          </div>
-                        </div>
-
-                        <% } else {%>
-                        <div class="received-chats">
-                          <div class="received-chats-img">
-                            <img src="/img/user2.png">
-                          </div>
-                          <div class="received-msg">
-                            <div class="received-msg-inbox">
-                              <p><%=data.message%></p>
-                              <span class="time"><%=data.date_time%> </span>
-                            </div>
-                          </div>
-                        </div>
-
-                        <% } i++; }) %>
-                        <% } else{ %>
-                                      <tr>
-                                          <td colspan="7">No Previous Conversation Found</td>
-                                      </tr>
-                        <% } %>
-
-
-                    </div>
-                  </div>
-                `;
-  }
-   setInterval('autoRefresh()', 5000);
-</script>
--->
+<!--Auto-scroll to most recent message on page load-->
 <script type="text/javascript">
   window.onload = function scroll_bottom()
   {

--- a/views/patient_messaging.ejs
+++ b/views/patient_messaging.ejs
@@ -47,6 +47,66 @@
 
     </style>
 </head>
+<!--
+<script>
+  function autoRefresh()
+  {
+    document.getElementById("msg-inbox").innerHTML = `
+    <div class="chats">
+                    <div class="msg-page">
+                      <%if(messageList.length!=0){%>
+                        <%var i=1;%>
+                        <% messageList.forEach(function(data){%>                     
+                      
+      
+                      <% if (data.sender_uuid == patient_uuid){ %>
+                        <div class="outgoing-chats">
+
+                          <div class="outgoing-chats-msg">
+                              <p style="background-color: #a8a8a8"><%=data.message%></p>
+                              <span class="time"><%=data.date_time%>  </span>
+
+                          </div>
+                          
+                          <div class="outgoing-chats-img">
+                            <img src="/img/user2.png">
+                          </div>
+                        </div>
+                        
+                        <% } else {%>
+                          <div class="received-chats">
+                            <div class="received-chats-img">
+                              <img src="/img/doctor_user.png">
+                            </div>
+                            <div class="received-msg">
+                              <div class="received-msg-inbox">
+                                <p><%=data.message%></p>
+                                <span class="time"><%=data.date_time%> </span>
+                              </div>
+                            </div>
+                          </div>
+                        <% } i++; }) %>
+                      <% } else{ %>
+                          <tr>
+                              <td colspan="7">No Previous Conversation Found</td>
+                          </tr>
+                        <% } %>
+                        
+                       
+                    </div>
+                  </div>
+                `;
+  }
+   setInterval('autoRefresh()', 5000);
+</script>
+-->
+<script type="text/javascript">
+  window.onload = function scroll_bottom()
+  {
+  var elem = document.getElementById('msg-inbox');
+  elem.scrollTop = elem.scrollHeight;
+  }
+</script>
 
 <body>
 
@@ -115,7 +175,7 @@
               </div>
 
               <div class="chat-page">
-                <div class="msg-inbox">
+                <div class="msg-inbox" id="msg-inbox">
                   <div class="chats">
                     <div class="msg-page">
                       <%if(messageList.length!=0){%>

--- a/views/patient_messaging.ejs
+++ b/views/patient_messaging.ejs
@@ -47,59 +47,8 @@
 
     </style>
 </head>
-<!--
-<script>
-  function autoRefresh()
-  {
-    document.getElementById("msg-inbox").innerHTML = `
-    <div class="chats">
-                    <div class="msg-page">
-                      <%if(messageList.length!=0){%>
-                        <%var i=1;%>
-                        <% messageList.forEach(function(data){%>                     
-                      
-      
-                      <% if (data.sender_uuid == patient_uuid){ %>
-                        <div class="outgoing-chats">
 
-                          <div class="outgoing-chats-msg">
-                              <p style="background-color: #a8a8a8"><%=data.message%></p>
-                              <span class="time"><%=data.date_time%>  </span>
-
-                          </div>
-                          
-                          <div class="outgoing-chats-img">
-                            <img src="/img/user2.png">
-                          </div>
-                        </div>
-                        
-                        <% } else {%>
-                          <div class="received-chats">
-                            <div class="received-chats-img">
-                              <img src="/img/doctor_user.png">
-                            </div>
-                            <div class="received-msg">
-                              <div class="received-msg-inbox">
-                                <p><%=data.message%></p>
-                                <span class="time"><%=data.date_time%> </span>
-                              </div>
-                            </div>
-                          </div>
-                        <% } i++; }) %>
-                      <% } else{ %>
-                          <tr>
-                              <td colspan="7">No Previous Conversation Found</td>
-                          </tr>
-                        <% } %>
-                        
-                       
-                    </div>
-                  </div>
-                `;
-  }
-   setInterval('autoRefresh()', 5000);
-</script>
--->
+<!--Auto-scroll to most recent message on page load-->
 <script type="text/javascript">
   window.onload = function scroll_bottom()
   {


### PR DESCRIPTION
After trying and researching some alternatives to make the messaging "live". The changes required aren't really worth doing considering the time and effort needed.

The only change made is a fix for #195 which makes the message box auto scroll to the most recent one when the page is loaded.